### PR TITLE
Fix workflow: update Gemini model + enable APPROVE_REVIEWS

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: "google" # or "anthropic" or "google"
           AI_API_KEY: ${{ secrets.GOOGLE_AI_KEY }}
-          AI_MODEL: "gemini-2.5-pro-exp-03-25"
+          AI_MODEL: "gemini-2.5-pro"
           AI_TEMPERATURE: 0.3 # 0 to 1 - higher values = more creativity and variance
           MAX_COMMENTS: 5 # Optional: defaults to 10
           APPROVE_REVIEWS: false # Optional: defaults to false

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -35,5 +35,5 @@ jobs:
           AI_MODEL: "gemini-2.5-pro"
           AI_TEMPERATURE: 0.3 # 0 to 1 - higher values = more creativity and variance
           MAX_COMMENTS: 5 # Optional: defaults to 10
-          APPROVE_REVIEWS: false # Optional: defaults to false
+          APPROVE_REVIEWS: true
           EXCLUDE_PATTERNS: "yarn.lock,dist/**"


### PR DESCRIPTION
Two small workflow fixes bundled together (same file, both small):

1. **Gemini model**: \`gemini-2.5-pro-exp-03-25\` → \`gemini-2.5-pro\`. The experimental release was retired; every PR run on \`main\` was failing with a 404 from \`generativelanguage.googleapis.com\`.
2. **\`APPROVE_REVIEWS: true\`**: let the action approve PRs on this repo (was \`false\`). The inline comment \`defaults to false\` was also wrong — \`action.yml\` defaults it to \`true\` — so it has been removed.

## Test plan

- [ ] After merge, the next PR opened against this repo should successfully run AI Code Reviewer end-to-end against Gemini, and the bot should be able to issue an APPROVE.