### PR TITLE
Prevent duplicate reviews via workflow concurrency group

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: write-all
 
+concurrency:
+  group: code-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   code_review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

PRs #18, #19, #20 each ended up with two duplicate AI reviews submitted seconds apart (e.g. https://github.com/keboola/ai-codereviewer/pull/18#pullrequestreview-4180134352 and https://github.com/keboola/ai-codereviewer/pull/18#pullrequestreview-4180134989). GitHub fired two workflow runs for the same head SHA — likely because both the head and the base branch changed at roughly the same time during the stack rebase.

## Fix

Add a \`concurrency\` group keyed on the PR number with \`cancel-in-progress: true\`. Any new run for the same PR cancels the previous one before it can post a second review.

\`\`\`yaml
concurrency:
  group: code-review-pr-\${{ github.event.pull_request.number }}
  cancel-in-progress: true
\`\`\`

## Test plan

- [ ] After merge + restacking #17–#20 on top of new main, opening a fresh PR or re-pushing should produce exactly one review.

## Note on existing duplicates

This fix only prevents future duplicates. The duplicate reviews already on #18–#20 stay unless we dismiss them manually — happy to do that in a follow-up if desired.