### PR TITLE
Configurable review trigger: auto on every PR + on-demand 'ai-review' label

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,10 +1,25 @@
-name: Code Review with OpenAI
+name: AI Code Review
+
+# Triggers:
+#   - Auto: every PR (and ready_for_review for drafts that get promoted)
+#   - On-demand re-trigger: apply the "ai-review" label to any PR
+#
+# Configure via GitHub Actions repository variables (Settings → Secrets and variables → Actions → Variables):
+#   AI_REVIEW_MODE          "auto" (default) — run automatically on every PR
+#                           "label"          — only run when the "ai-review" label is applied
+#   AI_REVIEW_INCLUDE_DRAFTS "false" (default) — skip drafts in auto mode
+#                           "true"            — also review drafts in auto mode
+#
+# Regardless of mode, applying the "ai-review" label always triggers a (re-)review.
 
 on:
   pull_request:
     types:
       - opened
       - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 permissions: write-all
 
@@ -15,9 +30,19 @@ concurrency:
 jobs:
   code_review:
     runs-on: ubuntu-latest
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'ai-review')
+      || (
+        github.event.action != 'labeled'
+        && (vars.AI_REVIEW_MODE == 'auto' || vars.AI_REVIEW_MODE == '')
+        && (
+          github.event.pull_request.draft == false
+          || vars.AI_REVIEW_INCLUDE_DRAFTS == 'true'
+        )
+      )
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -34,10 +59,26 @@ jobs:
         uses: ./.
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AI_PROVIDER: "google" # or "anthropic" or "google"
+          AI_PROVIDER: "google"
           AI_API_KEY: ${{ secrets.GOOGLE_AI_KEY }}
           AI_MODEL: "gemini-2.5-pro"
-          AI_TEMPERATURE: 0.3 # 0 to 1 - higher values = more creativity and variance
-          MAX_COMMENTS: 5 # Optional: defaults to 10
+          AI_TEMPERATURE: 0.3
+          MAX_COMMENTS: 5
           APPROVE_REVIEWS: true
           EXCLUDE_PATTERNS: "yarn.lock,dist/**"
+
+      - name: Remove ai-review label after re-trigger
+        if: always() && github.event.action == 'labeled' && github.event.label.name == 'ai-review'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'ai-review',
+              });
+            } catch (e) {
+              core.warning(`Could not remove label: ${e.message}`);
+            }

--- a/README.md
+++ b/README.md
@@ -32,21 +32,38 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
 permissions: write-all
+
+concurrency:
+  group: code-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'ai-review'
+    # Run when:
+    #   - the "ai-review" label was just applied (manual re-trigger), OR
+    #   - mode is "auto" (default) and the PR is not a draft (or drafts are explicitly allowed).
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'ai-review')
+      || (
+        github.event.action != 'labeled'
+        && (vars.AI_REVIEW_MODE == 'auto' || vars.AI_REVIEW_MODE == '')
+        && (
+          github.event.pull_request.draft == false
+          || vars.AI_REVIEW_INCLUDE_DRAFTS == 'true'
+        )
+      )
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: AI Code Review
         uses: keboola/ai-code-reviewer@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
           # Choose your AI provider and key
           AI_PROVIDER: "openai" # or "anthropic" or "google"
           AI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -59,15 +76,34 @@ jobs:
           PROJECT_CONTEXT: "This is a Node.js TypeScript project"
           CONTEXT_FILES: "package.json,README.md"
           EXCLUDE_PATTERNS: "**/*.lock,**/*.json,**/*.md"
-      
-      - name: Remove Label
-        uses: mondeja/remove-labels-gh-action@v2
+
+      - name: Remove ai-review label after re-trigger
+        if: always() && github.event.action == 'labeled' && github.event.label.name == 'ai-review'
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: ai-review
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'ai-review',
+              });
+            } catch (e) {
+              core.warning(`Could not remove label: ${e.message}`);
+            }
 ```
 
-With this configuration when you apply tag `ai-review` bot will do review to your PR and then remove tag itself.
+### Trigger modes
+
+Configure via Actions **repository variables** (`Settings → Secrets and variables → Actions → Variables`):
+
+| Variable | Values | Default | Effect |
+|---|---|---|---|
+| `AI_REVIEW_MODE` | `auto`, `label` | `auto` | `auto` runs on every non-draft PR. `label` only runs when the `ai-review` label is applied. |
+| `AI_REVIEW_INCLUDE_DRAFTS` | `true`, `false` | `false` | When `true` and `AI_REVIEW_MODE=auto`, drafts are also reviewed. |
+
+Regardless of mode, applying the `ai-review` label to any PR always triggers a fresh review. The label is removed automatically when the run finishes — apply it again to re-review.
 
 ## Configuration
 


### PR DESCRIPTION
## What this does

The bot now runs in two coexisting modes:

1. **Auto** (default) — review every PR on open / synchronize / ready-for-review.
2. **On-demand** — apply the `ai-review` label to any PR (including drafts already reviewed) to force a fresh review. The label is removed automatically when the run finishes — re-apply to re-review.

About the "re-review button under the bot's name": GitHub's `github-actions[bot]` cannot be added as a reviewer, and the standard `GITHUB_TOKEN` cannot impersonate one, so the only built-in click-to-rerun mechanism is the **label trigger** — which is what this PR wires up.

## Configuration

Two **Actions repository variables** (`Settings → Secrets and variables → Actions → Variables`) tune behavior — no workflow edits needed:

| Variable | Values | Default | Effect |
|---|---|---|---|
| `AI_REVIEW_MODE` | `auto` \| `label` | `auto` | `auto` reviews every non-draft PR. `label` only reviews on `ai-review` label. |
| `AI_REVIEW_INCLUDE_DRAFTS` | `true` \| `false` | `false` | When `true` (and mode is `auto`), drafts are also reviewed. |

Regardless of `AI_REVIEW_MODE`, the `ai-review` label always triggers a review.

## Changes

- `.github/workflows/code_review.yml` — expanded triggers, gating `if`, label-removal step, plus rebrand to "AI Code Review" (was "Code Review with OpenAI" — misleading since the workflow uses Gemini).
- `README.md` — Setup example mirrors the new pattern with the same trigger modes documented.

## Test plan

- [ ] Open a PR → workflow runs once (auto mode default).
- [ ] Open a draft PR → workflow does NOT run.
- [ ] Set `AI_REVIEW_INCLUDE_DRAFTS=true` → next draft PR opens with a review.
- [ ] Apply `ai-review` label to a PR previously reviewed → workflow runs again, label is removed when done.
- [ ] Set `AI_REVIEW_MODE=label` → opening a new PR does not trigger; only `ai-review` label does.