### PR TITLE
Auto-rebuild dist/ on every PR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Hide generated bundle from GitHub's PR diff view by default and
+# signal "don't review this" — actual source lives in src/. The bundle
+# is rebuilt automatically by .github/workflows/rebuild-dist.yml.
+dist/index.js     linguist-generated=true binary
+dist/index.js.map linguist-generated=true binary
+dist/licenses.txt linguist-generated=true

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -1,0 +1,68 @@
+name: Rebuild dist/
+
+# Rebuilds the bundled dist/ entry point on every PR that touches the
+# source. Eliminates the "you forgot to run yarn package" / "merge
+# conflict in dist/" friction. The committed dist/ is what the action
+# consumers run, so it has to stay in sync with src/ — but contributors
+# never have to think about that.
+#
+# - Only runs on PRs from this repo's branches (forks have a read-only
+#   GITHUB_TOKEN, can't push back).
+# - Only triggers when source-relevant files change (filters below) —
+#   commits that only touch dist/ themselves don't re-trigger this.
+# - cancel-in-progress avoids racing rebuilds when commits arrive fast.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'action.yml'
+      - '.github/workflows/rebuild-dist.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rebuild-dist-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rebuild:
+    # Skip on PRs from forks — GITHUB_TOKEN is read-only there.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          # Use a token that can push back to the PR branch.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Rebuild dist/
+        run: yarn package
+
+      - name: Commit and push if dist/ changed
+        run: |
+          if git diff --quiet -- dist/; then
+            echo "dist/ is already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "chore: rebuild dist/"
+          git push
+          echo "Pushed rebuilt dist/ to ${{ github.head_ref }}"

--- a/README.md
+++ b/README.md
@@ -359,7 +359,9 @@ yarn build
 # Run unit tests
 yarn test
 
-# Package for distribution
+# Package for distribution (rebuilds dist/index.js — done automatically by
+# .github/workflows/rebuild-dist.yml on every PR; you only need to run this
+# locally if you're testing the action with `act` or similar)
 yarn package
 
 # Generate test PR payload (for e2e testing)


### PR DESCRIPTION
## Why

Two recurring frictions on this repo:

1. **Contributors forget \`yarn package\` before pushing.** Result: action runs at \`@main\` are stale until someone notices.
2. **Merge conflicts in \`dist/\` during rebases.** We just hit this on PR #36 — every stack rebase requires \`yarn package\` + manual \`git checkout --theirs dist/index.js.map\`. Boring, error-prone, every time.

Both go away if CI rebuilds \`dist/\` for us.

## What

A new workflow \`.github/workflows/rebuild-dist.yml\` runs on PR \`opened\`/\`synchronize\`/\`reopened\` when source-relevant files change:

- \`src/**\`, \`package.json\`, \`yarn.lock\`, \`tsconfig.json\`, \`action.yml\`, and the workflow itself

It rebuilds the bundle and commits/pushes back to the PR branch **only if \`dist/\` actually differs** from what's committed.

## Safeguards

- **No infinite loop.** The \`paths:\` filter excludes \`dist/\` itself, so the rebuild commit (which only touches \`dist/\`) does NOT re-trigger the workflow.
- **No fork-PR breakage.** \`if: head.repo.full_name == github.repository\` skips PRs from forks where \`GITHUB_TOKEN\` is read-only.
- **No racing.** \`concurrency: cancel-in-progress: true\` cancels older runs when a new commit arrives.
- **Idempotent.** \`git diff --quiet -- dist/\` short-circuits when nothing changed.

## Bonus: \`.gitattributes\`

Added \`.gitattributes\` flagging \`dist/index.js\` and \`dist/index.js.map\` as \`linguist-generated=true binary\`. Effects:

- GitHub's PR review UI **hides** them in the diff by default (reviewers see "X files changed" but the dist diff is collapsed under "Load diff").
- They stop being counted toward language stats on the repo home.
- Conflict markers in them never appear (binary attribute) — git just picks a side, which is fine since CI will rebuild it anyway.

## Test plan

- [ ] Merge this PR. The workflow itself runs on PR-open against \`main\` and finds \`dist/\` already in sync — clean run.
- [ ] On the next contributor PR that touches \`src/\`, observe an automatic \`chore: rebuild dist/\` commit appearing seconds after their push.
- [ ] On a PR that ONLY touches docs/tests/etc, the workflow doesn't run (filtered out).